### PR TITLE
fix: small fixes

### DIFF
--- a/Common/config.py
+++ b/Common/config.py
@@ -56,8 +56,7 @@ REDIRECT_VN_FROM_INDEX_STDOUT = 0
 # how many dan wallets should print to console
 REDIRECT_DAN_WALLET_STDOUT = 0
 # The register vn cli is redirected as VN, this is for the publish template etc.
-REDIRECT_VN_CLI_STDOUT = True
-REDIRECT_INDEXER_STDOUT = True
+REDIRECT_INDEXER_STDOUT = 0
 # This is for the cargo generate and compilation for the template
 REDIRECT_CARGO_INSTALL_CARGO_GENERATE_STDOUT = True
 REDIRECT_TEMPLATE_STDOUT = True

--- a/Processes/common_exec.py
+++ b/Processes/common_exec.py
@@ -40,7 +40,7 @@ class CommonExec:
 
     def run(self, redirect: Union[bool, int], cwd: Optional[str] = None):
         env: dict[str, str] = os.environ.copy()
-        if (self.id is not None and self.id >= redirect) or (not self.id and redirect):
+        if (self.id is not None and self.id >= redirect) or (self.id is None and redirect):
             self.process = SubprocessWrapper.Popen(
                 self.exec,
                 stdin=subprocess.PIPE,

--- a/main.py
+++ b/main.py
@@ -223,7 +223,7 @@ def stress_test():
 
     def send_tx(account0: int, account1: int):
         global total_num_of_tx
-        res_addr = [1] * 32
+        res_addr = "resource_0101010101010101010101010101010101010101010101010101010101010101"
         acc0, dan0 = accounts[account0]
         acc1, dan1 = accounts[account1]
         public_key0 = acc0["public_key"]


### PR DESCRIPTION
Fixes:
- resource address is now to be expected in human readable format
- redirecting output (for some processes) was always on (no matter the config)