### PR TITLE
feat: add jrpc indexer webui address

### DIFF
--- a/Processes/indexer.py
+++ b/Processes/indexer.py
@@ -18,7 +18,8 @@ class Indexer(CommonExec):
         self.public_port = self.get_port("public_address")
         self.public_adress = f"/ip4/{local_ip}/tcp/{self.public_port}"
         self.json_rpc_port = self.get_port("JRPC")
-        self.json_rpc_address = f"{local_ip}:{self.json_rpc_port}"
+        self.json_rpc_address = f"0.0.0.0:{self.json_rpc_port}"
+        self.jrpc_for_ui_address = f"{local_ip}:{self.json_rpc_port}"
         self.http_port = self.get_port("HTTP")
         self.http_ui_address = f"{local_ip}:{self.http_port}"
         if USE_BINARY_EXECUTABLE:
@@ -57,9 +58,11 @@ class Indexer(CommonExec):
             f"indexer.json_rpc_address={self.json_rpc_address}",
             "-p",
             f"indexer.http_ui_address={self.http_ui_address}",
+            "-p",
+            f"indexer.jrpc_for_ui_address={self.jrpc_for_ui_address}"
         ]
         self.run(REDIRECT_INDEXER_STDOUT)
-        self.jrpc_client = JrpcIndexer(f"http://{self.json_rpc_address}")
+        self.jrpc_client = JrpcIndexer(f"http://{self.jrpc_for_ui_address}")
         while not os.path.exists(os.path.join(DATA_FOLDER, f"indexer_{self.id}", "localnet", "pid")):
             if self.process.poll() is None:
                 time.sleep(1)
@@ -81,7 +84,7 @@ class Indexer(CommonExec):
         return f"{public_key}::{public_address}"
 
     def get_info_for_ui(self):
-        return {"http": self.http_ui_address, "jrpc": self.json_rpc_address}
+        return {"http": self.http_ui_address, "jrpc": self.jrpc_for_ui_address}
 
 
 class JrpcIndexer:

--- a/webui.py
+++ b/webui.py
@@ -29,11 +29,15 @@ class JrpcHandler(BaseHTTPRequestHandler):
                 form_data = cgi.FieldStorage(fp=self.rfile, headers=self.headers, environ={"REQUEST_METHOD": "POST"})
                 if "file" in form_data:
                     uploaded_file = form_data["file"]
+                    try:
+                        os.makedirs(os.path.join(DATA_FOLDER, "templates"))
+                    except:
+                        pass
                     f = open(os.path.join(DATA_FOLDER, "templates", uploaded_file.filename), "wb")
                     f.write(uploaded_file.file.read())
                     f.close()
                     template = Template(uploaded_file.filename, from_source=False)
-                    template.publish_template(validator_nodes.any_node().json_rpc_port, self.commands.server.port, local_ip)
+                    template.publish_template(self.commands.validator_nodes.any_node().json_rpc_port, self.commands.server.port, local_ip)
                     self.send_response(200)
                     self.send_header("Content-type", "text/html")
                     self.end_headers()


### PR DESCRIPTION
Set the indexer jrpc listening address to `0.0.0.0:<port>` and the connect jrpc address for ui to `127.0.0.1:<port>` this way you can connect indexer webui from different address than localhost (e.g. deploy it to a web).

This has to go after the [PR](https://github.com/tari-project/tari-dan/pull/738) on tari-dan