### PR TITLE
fix: correct indexer-url parameter in wallet daemon

### DIFF
--- a/Processes/dan_wallet_daemon.py
+++ b/Processes/dan_wallet_daemon.py
@@ -145,7 +145,7 @@ class DanWalletDaemon(CommonExec):
             "localnet",
             "--json-rpc-address",
             self.json_listen_address,
-            "--indexer_url",
+            "--indexer-url",
             f"http://{local_ip}:{indexer_jrpc_port}/json_rpc",
             "-p",
             f"dan_wallet_daemon.http_ui_address={self.http_listen_address}",


### PR DESCRIPTION
Recently the `indexer_url` CLI parameter in the wallet daemon was rewritten to `indexer-url`, so we need to adapt the `dan-testing` project accordingly