### PR TITLE
chore: show proper errors

### DIFF
--- a/Collections/validator_nodes.py
+++ b/Collections/validator_nodes.py
@@ -62,7 +62,7 @@ class ValidatorNodes:
             # miner.mine(1)
         print("done")
 
-            # Wait until they are all in the mempool
+        # Wait until they are all in the mempool
         i = 0
         print("Waiting for X tx's in mempool.", end="")
         while i < 10:

--- a/Processes/base_node.py
+++ b/Processes/base_node.py
@@ -4,7 +4,7 @@
 from grpc import insecure_channel
 
 try:
-    from protos import types_pb2, base_node_pb2_grpc
+    from protos import types_pb2, base_node_pb2_grpc, base_node_pb2
 except:
     print("You forgot to generate protos, run protos.sh or protos.bat")
     exit()
@@ -49,6 +49,10 @@ class GrpcBaseNode:
 
     def get_tip(self) -> int:
         return self.get_tip_info().metadata.height_of_longest_chain
+
+    def get_active_validator_nodes(self, height: int):
+        request = base_node_pb2.GetActiveValidatorNodesRequest(height=height)
+        return self.stub.GetActiveValidatorNodes(request)
 
 
 class BaseNode(CommonExec):

--- a/Processes/base_node.py
+++ b/Processes/base_node.py
@@ -87,6 +87,8 @@ class BaseNode(CommonExec):
             # f'{NETWORK}.p2p.seeds.peer_seeds="369ae9a89c3fc2804d6ec07e20bf10e5d0e72f565a71821fc7c611ae5bee0116::/ip4/34.252.174.111/tcp/18000"',
             "-p",
             "base_node.metadata_auto_ping_interval=3",
+            "-p",
+            "base_node.report_grpc_error=true",
         ]
         self.run(REDIRECT_BASE_NODE_STDOUT)
         # Sometimes it takes a while to establish the grpc connection
@@ -95,8 +97,8 @@ class BaseNode(CommonExec):
                 self.grpc_client = GrpcBaseNode(f"{local_ip}:{self.grpc_port}")
                 self.grpc_client.get_version()
                 break
-            except:
-                pass
+            except Exception as e:
+                print(e)
             time.sleep(1)
 
     def get_address(self) -> str:

--- a/Processes/dan_wallet_daemon.py
+++ b/Processes/dan_wallet_daemon.py
@@ -41,9 +41,9 @@ class JrpcDanWalletDaemon:
     def keys_list(self):
         return self.call("keys.list")
 
-    def accounts_create(self, name: str, custom_access_rules: Any = None, fee: Optional[int] = None, is_default: bool = True):
+    def accounts_create(self, name: str, custom_access_rules: Any = None, fee: Optional[int] = None, is_default: bool = True, key_id: Optional[int] = None):
         id = stats.start_run("accounts.create")
-        res = self.call("accounts.create", [name, custom_access_rules, fee, is_default])
+        res = self.call("accounts.create", [name, custom_access_rules, fee, is_default, key_id])
         self.last_account_name = name
         stats.end_run(id)
         return res

--- a/Processes/dan_wallet_daemon.py
+++ b/Processes/dan_wallet_daemon.py
@@ -109,7 +109,7 @@ class JrpcDanWalletDaemon:
         return self.call("accounts.get_balances", [account["account"]["name"], True])
 
     def transfer(self, account: Any, amount: int, resource_address: Any, destination_publickey: Any, fee: Optional[int]):
-        id = stats.start_run("accounts.create_free_test_coins")
+        id = stats.start_run("accounts.transfer")
         res = self.call("accounts.transfer", [account["account"]["name"], amount, resource_address, destination_publickey, fee])
         stats.end_run(id)
         return res

--- a/Processes/wallet.py
+++ b/Processes/wallet.py
@@ -84,8 +84,8 @@ class Wallet(CommonExec):
                 self.grpc_client = GrpcWallet(f"{local_ip}:{self.grpc_port}")
                 self.grpc_client.get_version()
                 break
-            except:
-                pass
+            except Exception as e:
+                print(e)
             time.sleep(1)
 
     def stop(self):

--- a/main.py
+++ b/main.py
@@ -217,10 +217,10 @@ def cli_loop():
     del server
 
 
-def stress_test():
+# this is how many times we send the funds back and forth for each of two wallets
+def stress_test(num_of_tx: int = 1):
     global base_node, miner, tari_connector_sample, server
     global total_num_of_tx
-    num_of_tx = 10  # this is how many times we send the funds back and forth for each of two wallets
     total_num_of_tx = 0
 
     def send_tx(account0: int, account1: int):
@@ -232,9 +232,9 @@ def stress_test():
         public_key1 = acc1["public_key"]
         for i in range(num_of_tx):
             print(f"tx {account0} -> {account1} ({i})")
-            # dan_wallets[src_id].jrpc_client.confidential_transfer(src_account, 1, res_addr, dst_public_key, 1)
-            # dan_wallets[dst_id].jrpc_client.confidential_transfer(dst_account, 1, res_addr, src_public_key, 1)
-            dan0.jrpc_client.transfer(acc0, 1, res_addr, public_key1, 2000)
+            # dan0.jrpc_client.confidential_transfer(acc0, 1, res_addr, public_key1, 2000)
+            # dan1.jrpc_client.confidential_transfer(acc1, 1, res_addr, public_key0, 2000)
+            dan0.jrpc_client.transfer(acc0, 2000, res_addr, public_key1, 2000)
             total_num_of_tx += 1
             # dan_wallets[dst_id].jrpc_client.transfer(dst_account, 1, res_addr, src_public_key, 2000)
 
@@ -437,11 +437,12 @@ try:
                     time.sleep(1)
                 else:
                     break
-            for acc in accs:
+            for acc in sorted(accs, key=lambda acc: acc["account"]["name"]):
                 accounts[acc["account"]["name"]] = (acc, dan_wallets[did])
         print()
         # burns = {}
         # accounts = {}
+        # BURN_AMOUNT = 10000
         # print_step(f"BURNING {BURN_AMOUNT}")
         # for id in dan_wallets:
         #     dan_wallet_jrpc = dan_wallets[id].jrpc_client


### PR DESCRIPTION
Show proper errors in python, including the rpc errors from base node.
Add missing key_id parameter to the accounts.create