### PR TITLE
fix: showing base nodes instead of base wallet

### DIFF
--- a/webui/src/routes/Main.tsx
+++ b/webui/src/routes/Main.tsx
@@ -462,8 +462,8 @@ export default function Main() {
       <div>
         <div className="label">Base Wallets</div>
         <ShowInfos
-          nodes={baseNodes}
-          executable={Executable.BaseNode}
+          nodes={baseWallets}
+          executable={Executable.BaseWallet}
           logs={logs}
           stdoutLogs={stdoutLogs}
           showLogs={showLogs}


### PR DESCRIPTION
The base wallets were not shown, instead the base nodes were there twice.