### PR TITLE
fix: the listening address of signaling server

### DIFF
--- a/Processes/signaling_server.py
+++ b/Processes/signaling_server.py
@@ -23,7 +23,7 @@ class SignalingServer(CommonExec):
             "-b",
             os.path.join(DATA_FOLDER, "signaling_server"),
             "--listen-addr",
-            f"{local_ip}:{self.json_rpc_port}",
+            f"0.0.0.0:{self.json_rpc_port}",
         ]
         self.run()
         print("Waiting for signaling server to start.", end="")


### PR DESCRIPTION
The listening address should be 0.0.0.0 otherwise it will not listen outside of the docker image. So you will not be able to connect from the webui requesting to connect from the browser.